### PR TITLE
Use getGameInfo to fetch lobby data

### DIFF
--- a/multiplayer-lobby.html
+++ b/multiplayer-lobby.html
@@ -718,7 +718,7 @@
                 }
             }
 
-            async getGameData(gameId) {
+            async getGameInfo(gameId) {
                 if (!this.isConnected) return null;
 
                 try {
@@ -726,7 +726,7 @@
                     const snapshot = await gameRef.once('value');
                     return snapshot.exists() ? snapshot.val() : null;
                 } catch (error) {
-                    console.error('❌ Get game data failed:', error);
+                    console.error('❌ Get game info failed:', error);
                     return null;
                 }
             }
@@ -1161,7 +1161,7 @@
             console.log('🔄 Loading initial Firebase data...');
             
             try {
-                const gameData = await firebaseService.getGameData(gameState.gameId);
+                const gameData = await firebaseService.getGameInfo(gameState.gameId);
                 if (gameData) {
                     console.log('✅ Initial game data loaded:', gameData);
                     currentGameData = gameData;


### PR DESCRIPTION
## Summary
- Replace missing `getGameData` call with existing `getGameInfo` in the multiplayer lobby
- Rename Firebase lobby helper to `getGameInfo` for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a6dbcf78833381050fb6e7e3c044