### PR TITLE
Fix Firebase initialization in multiplayer category flow

### DIFF
--- a/firebase-service.js
+++ b/firebase-service.js
@@ -41,8 +41,6 @@ class FirebaseGameService {
             this.database = firebase.database();
 
             // Connection test
-
-            try {
             const testRef = this.database.ref('.info/connected');
             const snapshot = await Promise.race([
                 testRef.once('value'),
@@ -50,7 +48,6 @@ class FirebaseGameService {
             ]);
 
             this.isConnected = snapshot.val() === true;
-
             this.isInitialized = this.isConnected;
 
             if (this.isConnected && gameId) {

--- a/multiplayer-category-selection.html
+++ b/multiplayer-category-selection.html
@@ -902,9 +902,14 @@
                 gameState.load();
                 firebaseService = new FirebaseGameService();
                 
-                // Initialize Firebase
-                const firebaseReady = await firebaseService.initialize();
+                // Initialize Firebase (connect if game already exists)
+                const firebaseReady = await firebaseService.initialize(gameState.gameId);
                 console.log(`🔥 Firebase ready: ${firebaseReady}`);
+                if (!firebaseReady) {
+                    showNotification('Firebase-Verbindung fehlgeschlagen', 'error');
+                    hideLoading();
+                    return;
+                }
                 
                 // Verify multiplayer state
                 console.log('🔍 Current GameState:', gameState.getDebugInfo());


### PR DESCRIPTION
## Summary
- Correct Firebase initialization logic in `firebase-service.js`
- Ensure multiplayer category selection connects to Firebase with the current game ID and handles connection failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c225a56483338e68c1fe013961bd