### PR TITLE
Ensure Firebase connection initializes across multiplayer setup

### DIFF
--- a/firebase-service.js
+++ b/firebase-service.js
@@ -41,8 +41,6 @@ class FirebaseGameService {
             this.database = firebase.database();
 
             // Connection test
-
-            try {
             const testRef = this.database.ref('.info/connected');
             const snapshot = await Promise.race([
                 testRef.once('value'),
@@ -50,15 +48,16 @@ class FirebaseGameService {
             ]);
 
             this.isConnected = snapshot.val() === true;
-
-            this.isInitialized = this.isConnected;
+            let connectSuccess = true;
 
             if (this.isConnected && gameId) {
-                await this.connectToGame(gameId, callbacks);
+                connectSuccess = await this.connectToGame(gameId, callbacks);
             }
 
-            console.log(`✅ Firebase: ${this.isConnected ? 'connected' : 'failed'}`);
-            return this.isConnected;
+            this.isInitialized = this.isConnected && connectSuccess;
+
+            console.log(`✅ Firebase: ${this.isInitialized ? 'connected' : 'failed'}`);
+            return this.isInitialized;
 
         } catch (error) {
             console.error('❌ Firebase init failed:', error);

--- a/multiplayer-category-selection.html
+++ b/multiplayer-category-selection.html
@@ -902,10 +902,18 @@
                 gameState.load();
                 firebaseService = new FirebaseGameService();
                 
-                // Initialize Firebase
-                const firebaseReady = await firebaseService.initialize();
+                // Initialize Firebase (connect if game already exists)
+                const firebaseReady = await firebaseService.initialize(gameState.gameId);
                 console.log(`🔥 Firebase ready: ${firebaseReady}`);
-                
+                if (!firebaseReady) {
+                    showNotification('Firebase-Verbindung fehlgeschlagen', 'error');
+                    hideLoading();
+                    return;
+                }
+
+                // Track connection status
+                setupConnectionStatus();
+
                 // Verify multiplayer state
                 console.log('🔍 Current GameState:', gameState.getDebugInfo());
                 
@@ -1047,6 +1055,18 @@
                 console.error('❌ Error in continueWithExistingName:', error);
                 showNotification('Setup-Fehler', 'warning');
             }
+        }
+
+        // Listen for connection changes and update status display
+        function setupConnectionStatus() {
+            const statusEl = document.getElementById('connection-status');
+            if (!statusEl || !firebaseService) return;
+
+            firebaseService.onConnectionChange((connected) => {
+                statusEl.textContent = connected ? 'Online' : 'Offline';
+                statusEl.classList.remove('connecting', 'connected', 'disconnected');
+                statusEl.classList.add(connected ? 'connected' : 'disconnected');
+            });
         }
 
         // KRITISCHER FIX: Neue createGameInFirebase Funktion

--- a/multiplayer-difficulty-selection.html
+++ b/multiplayer-difficulty-selection.html
@@ -1168,6 +1168,9 @@
                 
                 // Initialize services
                 gameState = new GameState();
+                if (gameState.loadFromStorage) {
+                    gameState.loadFromStorage();
+                }
                 firebaseService = new FirebaseGameService();
                 
                 // Validate multiplayer state
@@ -1182,6 +1185,7 @@
                     onSettings: handleSettingsUpdate
                 });
                 if (!firebaseOk) {
+                    console.error('❌ Firebase initialization failed');
                     showNotification('Firebase-Verbindung fehlgeschlagen', 'error');
                     hideLoading();
                     return;


### PR DESCRIPTION
## Summary
- Return a failure from Firebase initialization when connecting to a game fails
- Track realtime connection status on multiplayer category selection page
- Reload stored state before initializing Firebase on difficulty selection page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c225a56483338e68c1fe013961bd