### PR TITLE
Fix uncaught promise rejections in multiplayer modules

### DIFF
--- a/assets/js/multiplayer-gameplay.js
+++ b/assets/js/multiplayer-gameplay.js
@@ -1416,6 +1416,10 @@
                         isPaused = false;
                         getServerTimestamp().then(serverTime => {
                             startTimer(gameData.timerStartTime, gameData.timerRemaining || timerDuration);
+                        }).catch((error) => {
+                            console.error('❌ Error getting server timestamp:', error);
+                            // Fallback: start timer with local time
+                            startTimer(gameData.timerStartTime, gameData.timerRemaining || timerDuration);
                         });
                         showNotification('▶️ Timer fortgesetzt', 'info', 2000);
                     }

--- a/assets/js/multiplayer-results.js
+++ b/assets/js/multiplayer-results.js
@@ -1155,6 +1155,10 @@
                 // ✅ P1 STABILITY: Handle host leaving
                 handleHostLeaving().then(() => {
                     redirectToMenu();
+                }).catch((error) => {
+                    console.error('❌ Error handling host leaving:', error);
+                    // Still redirect even if host transfer fails
+                    redirectToMenu();
                 });
             });
         }
@@ -1178,6 +1182,10 @@
         if (goToMenuBtn) {
             addTrackedEventListener(goToMenuBtn, 'click', () => {
                 handleHostLeaving().then(() => {
+                    redirectToMenu();
+                }).catch((error) => {
+                    console.error('❌ Error handling host leaving:', error);
+                    // Still redirect even if host transfer fails
                     redirectToMenu();
                 });
             });


### PR DESCRIPTION
Added proper error handling with .catch() handlers to prevent unhandled promise rejections in:
- multiplayer-results.js: handleHostLeaving() calls (2 instances)
- multiplayer-gameplay.js: getServerTimestamp() call

These promise chains previously had no error handlers, which could cause silent failures and make debugging difficult. Now errors are logged to the console and graceful fallbacks are provided.