### PR TITLE
Fix Firebase initialization timing issue

### DIFF
--- a/assets/js/firebase-init.js
+++ b/assets/js/firebase-init.js
@@ -78,6 +78,9 @@
                         console.warn("⚠️ App Check TEMPORARILY DISABLED (reCAPTCHA misconfigured)");
                     }
 
+                    // ✅ FIX: Set global flag for other scripts to detect initialization
+                    window.firebaseInitialized = true;
+
                     if (isDevelopment) {
                         console.log("✅ Firebase initialized");
                     }

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -38,29 +38,14 @@
     // INIT
     // ===================================
 
-    function init() {
+    async function init() {
         Logger.info('🚀 Initializing Settings Module...');
 
-        // Wait for Firebase SDK to be loaded
-        if (!firebase || !firebase.app || !firebase.auth) {
-            Logger.warn('⚠️ Firebase SDK not loaded, retrying...');
-            setTimeout(init, 500);
-            return;
-        }
+        // ✅ FIX: Use waitForFirebaseInit from utils.js to avoid retry loops
+        const firebaseReady = await window.NocapUtils.waitForFirebaseInit(10000);
 
-        // Wait for Firebase App to be initialized by firebase-config.js
-        if (!window.firebaseInitialized) {
-            Logger.warn('⚠️ Firebase not initialized yet, retrying...');
-            setTimeout(init, 500);
-            return;
-        }
-
-        // Double-check Firebase App is accessible
-        try {
-            firebase.app();
-        } catch (error) {
-            Logger.warn('⚠️ Firebase App not accessible, retrying...', error.message);
-            setTimeout(init, 500);
+        if (!firebaseReady) {
+            Logger.error('❌ Firebase initialization timeout - Settings Module cannot start');
             return;
         }
 


### PR DESCRIPTION
Problem:
- settings.js hatte 4 Retries mit "Firebase not initialized yet"
- Race condition zwischen firebase-config.js und settings.js
- firebase-init.js setzte window.firebaseInitialized Flag nicht

Lösung:
- settings.js nutzt jetzt waitForFirebaseInit() aus utils.js
- firebase-init.js setzt jetzt window.firebaseInitialized Flag
- Eliminiert unnötige Retry-Schleifen und Warnungen

Keine weiteren Konsolen-Warnungen mehr!